### PR TITLE
GestureDetector drag fix

### DIFF
--- a/lib/src/spannable_grid_cell_view.dart
+++ b/lib/src/spannable_grid_cell_view.dart
@@ -67,7 +67,7 @@ class SpannableGridCellView extends StatelessWidget {
         if (editingStrategy.exitOnTap) {
           result = GestureDetector(
             onTap: onExitEditing,
-            onTapDown: (details) => onDragStarted(details.localPosition),
+            onPanDown: (details) => onDragStarted(details.localPosition),
             child: result,
           );
         }


### PR DESCRIPTION
Switch GestureDetector from `onTapDown` to `onPanDown` for `editingStrategy.exitOnTap`.  
This fixes the issue where sometimes the dragging does not react due to delay of `onTapDown`.