### PR TITLE
Fix cell not picking up properly when dragging

### DIFF
--- a/lib/src/spannable_grid_cell_view.dart
+++ b/lib/src/spannable_grid_cell_view.dart
@@ -67,8 +67,10 @@ class SpannableGridCellView extends StatelessWidget {
         if (editingStrategy.exitOnTap) {
           result = GestureDetector(
             onTap: onExitEditing,
-            onTapDown: (details) => onDragStarted(details.localPosition),
-            child: result,
+            child: Listener(
+              onPointerDown: (details) => onDragStarted(details.localPosition),
+              child: result,
+            ),
           );
         }
         result = Draggable<SpannableGridCellData>(


### PR DESCRIPTION
I noticed that onTapDown doesn't trigger as fast as the Draggable widget due to it checking whether another gesture was supposed to be triggered instead. I've added a Listener widget to allow it to pick up the widget at the same time as the Draggable component.
I considered using the onDragStarted callback but it doesn't return the pointer position which we need...